### PR TITLE
Add Dockerfile for image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["python", "main.py"]


### PR DESCRIPTION
## Summary
- add Dockerfile to containerize the Fibonacci retracement backtesting bot

## Testing
- `python -m py_compile main.py fib_strategy.py`
- `docker build -t fib-bot .` *(fails: Cannot connect to the Docker daemon)*


------
https://chatgpt.com/codex/tasks/task_e_68a5b208233c832a856df6597706d296